### PR TITLE
Removed format argument

### DIFF
--- a/Youtube Downloader/VideoInfo.swift
+++ b/Youtube Downloader/VideoInfo.swift
@@ -16,7 +16,7 @@ class VideoInfo: Codable {
     
     static func getVideoInfo(url: String) -> VideoInfo {
         let path   = String(Bundle.main.path(forResource: "youtube-dl", ofType: "")!)
-        let json = executeCommand(command: path, args: ["-f mp4/best", "--dump-json", url])
+        let json = executeCommand(command: path, args: ["--dump-json", url])
         
         let jsonDecoder = JSONDecoder()
         let info = try? jsonDecoder.decode(VideoInfo.self, from: json.data(using: .utf8)!)


### PR DESCRIPTION
Seems like 1080p downloads are somehow prohibited by YouTube. 
Still, youtube-dl is able to give me 720p downloads while this tool acts weird sometimes. I think it may be because of mp4 encoding requirements in [`VideoInfo.swift`](https://github.com/DenBeke/YouTube-Downloader-for-macOS/blob/master/Youtube%20Downloader/VideoInfo.swift)

Removed `"-f mp4/best"` as an argument because youtube-dl automatically defaults to highest quality available as seen in the youtube-dl [docs](https://github.com/ytdl-org/youtube-dl/#can-you-please-put-the--b-option-back) :

> Most people asking this question are not aware that youtube-dl now defaults to downloading the highest available quality as reported by YouTube, which will be 1080p or 720p in some cases, so you no longer need the -b option.