### PR TITLE
Automatically populate download field with clipboard content

### DIFF
--- a/Youtube Downloader/DownloadViewController.swift
+++ b/Youtube Downloader/DownloadViewController.swift
@@ -108,10 +108,6 @@ class DownloadViewController: NSViewController {
                 }
             }
         }
-        
-        
-        
-        
     }
     
     
@@ -134,6 +130,22 @@ class DownloadViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do view setup here.
+    }
+    
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        
+        getURLFromClipboard()
+    }
+    
+    func getURLFromClipboard() {
+        let readURL = NSPasteboard.general.pasteboardItems?.first?.string(forType: .string)
+        
+        if let clipboardContent = readURL {
+            if !clipboardContent.contains("youtube.com") { return }
+            guard let _ = URL(string: clipboardContent) else { return }
+            self.videoUrl.stringValue = clipboardContent
+        }
     }
     
     

--- a/Youtube Downloader/DownloadViewController.swift
+++ b/Youtube Downloader/DownloadViewController.swift
@@ -142,7 +142,7 @@ class DownloadViewController: NSViewController {
         let readURL = NSPasteboard.general.pasteboardItems?.first?.string(forType: .string)
         
         if let clipboardContent = readURL {
-            if !clipboardContent.contains("youtube.com") { return }
+            if !clipboardContent.contains("youtube.com") && !clipboardContent.contains("youtu.be") { return }
             guard let _ = URL(string: clipboardContent) else { return }
             self.videoUrl.stringValue = clipboardContent
         }


### PR DESCRIPTION
This PR adds the ability to automatically populate the URL from the clipboard providing the URL contains either youtube.com or youtu.be. This is done in the viewDidAppear method, so the content will be populated every time the window is opened.